### PR TITLE
Also rescue Errno::EHOSTDOWN in send method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 #CocoaPods Stats CHANGELOG
 
+## 0.5.4
+
+##### Bug Fixes
+
+* Also rescue Errno::EHOSTDOWN when sending stats (could be blocked by a
+  firewall and should not stop the user from installing pods)
+  [Clemens Gruber](https://github.com/clemensg)
+
+
 ## 0.5.3
 
 ##### Bug Fixes

--- a/lib/cocoapods_stats/sender.rb
+++ b/lib/cocoapods_stats/sender.rb
@@ -15,7 +15,7 @@ module CocoaPodsStats
         'Accept' => 'application/json',
         'Content-Type' => 'application/json',
       )
-    rescue REST::Error => e
+    rescue REST::Error, Errno::EHOSTDOWN => e
       Pod::UI.message "Failed to send stats:\n\n#{e}"
     end
   end


### PR DESCRIPTION
Otherwise `pod setup` fails, just because the stats upload is blocked.
This can happen behind a firewall or when using something like LittleSnitch on OS X.

Signed-off-by: Clemens Gruber <clemensgru@gmail.com>