### PR TITLE
Set curl's maximum timeout to 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Send stats to the API asynchronously and out of process.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Set maximum timeout of 30 seconds for asynchronous stats sending.  
+  [Boris Bügling](https://github.com/neonichu)
+
 
 ## 0.5.3
 

--- a/lib/cocoapods_stats/sender.rb
+++ b/lib/cocoapods_stats/sender.rb
@@ -21,7 +21,7 @@ module CocoaPodsStats
 
     def curl(url, json, headers)
       headers = headers.map { |k, v| ['-H', "#{k}: #{v}"] }.flatten
-      command = ['curl', *headers, '-X', 'POST', '-d', json.to_json, url]
+      command = ['curl', *headers, '-X', 'POST', '-d', json.to_json, '-m', '30', url]
       dev_null = '/dev/null'
       Process.spawn(*command, :out => dev_null, :err => dev_null)
     end


### PR DESCRIPTION
Let's ensure that the background curl processes don't run forever for any reason.

> -m, --max-time <seconds>
>              Maximum time in seconds that you allow the  whole  operation  to
>              take.   This is useful for preventing your batch jobs from hang-
>              ing for hours due to slow networks or links going  down.

cc @segiddins @orta 