### PR TITLE
Disable the hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 cache: bundler
+
+language: ruby
+dist: trusty
+
 rvm:
   # Same rubies as CP
   - 2.0.0-p647

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CocoaPods Stats CHANGELOG
 
+##### Enhancements
+
+* Disables the hook, because the server hasn't been keeping track of stats for years.  
+  [Orta Therox](https://github.com/orta)
+
 ## 1.1.0 (2019-01-24)
 
 ##### Enhancements

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -7,7 +7,8 @@ module CocoaPodsStats
 
   class OptOutValidator
     def validates?
-      ENV['COCOAPODS_DISABLE_STATS'].nil?
+      # Never runs the uploader, as it's not being used
+      false
     end
   end
 

--- a/spec/env_validator_spec.rb
+++ b/spec/env_validator_spec.rb
@@ -13,7 +13,7 @@ describe CocoaPodsStats::OptOutValidator do
       ENV['COCOAPODS_DISABLE_STATS'] = nil
 
       subject = CocoaPodsStats::OptOutValidator.new
-      subject.should.validates
+      subject.should.not.validates
     end
   end
 end


### PR DESCRIPTION
This can be in for a release or two, overwriting people's copy of cocoapods-stats then cocoapods-stats can be removed from the default dependencies effectively removing it entirely from the tree. 